### PR TITLE
GameRules for instances of more things that are affected by gamerule doMobGriefing

### DIFF
--- a/src/main/java/io/github/ennuil/damageincorporated/DamageIncorporatedMod.java
+++ b/src/main/java/io/github/ennuil/damageincorporated/DamageIncorporatedMod.java
@@ -37,6 +37,11 @@ public class DamageIncorporatedMod implements ModInitializer {
 	public static GameRules.Key<BooleanRule> CAN_SHEEP_TURN_GRASS_BLOCKS_INTO_DIRT_RULE;
 	public static GameRules.Key<BooleanRule> CAN_RABBITS_EAT_CARROT_CROPS_RULE;
 	public static GameRules.Key<BooleanRule> CAN_FOXES_EAT_IN_WORLD_BERRIES_RULE;
+	public static GameRules.Key<BooleanRule> CAN_ZOMBIES_BREAK_TURTLE_EGGS;
+	public static GameRules.Key<BooleanRule> CAN_DROWNEDS_BREAK_TURTLE_EGGS;
+	public static GameRules.Key<BooleanRule> CAN_ZOMBIFIED_PIGLINS_BREAK_TURTLE_EGGS;
+	public static GameRules.Key<BooleanRule> CAN_HUSKS_BREAK_TURTLE_EGGS;
+	public static GameRules.Key<BooleanRule> CAN_ZOMBIE_VILLAGERS_BREAK_TURTLE_EGGS;
 	public static enum FARMLAND_TRAMPLING_ENUM {
 		ALL,
 		PLAYER,
@@ -66,5 +71,11 @@ public class DamageIncorporatedMod implements ModInitializer {
 		CAN_SHEEP_TURN_GRASS_BLOCKS_INTO_DIRT_RULE = GameRuleRegistry.register("canSheepTurnGrassBlocksIntoDirt", DAMAGE_INCORPORATED_CATEGORY, GameRuleFactory.createBooleanRule(true));
 		CAN_RABBITS_EAT_CARROT_CROPS_RULE = GameRuleRegistry.register("canRabbitsEatCarrotCrops", DAMAGE_INCORPORATED_CATEGORY, GameRuleFactory.createBooleanRule(true));
 		CAN_FOXES_EAT_IN_WORLD_BERRIES_RULE = GameRuleRegistry.register("canFoxesEatInWorldBerries", DAMAGE_INCORPORATED_CATEGORY, GameRuleFactory.createBooleanRule(true));
+		CAN_ZOMBIES_BREAK_TURTLE_EGGS = GameRuleRegistry.register("canZombiesBreakTurtleEggs", DAMAGE_INCORPORATED_CATEGORY, GameRuleFactory.createBooleanRule(true));
+		CAN_DROWNEDS_BREAK_TURTLE_EGGS = GameRuleRegistry.register("canDrownedBreakTurtleEggs", DAMAGE_INCORPORATED_CATEGORY, GameRuleFactory.createBooleanRule(true));
+		//CAN_SKELENTONS_BREAK_TURTLE_EGGS = GameRuleRegistry.register("canSkeletonsBreakTurtleEggs", DAMAGE_INCORPORATED_CATEGORY, GameRuleFactory.createBooleanRule(true));
+		CAN_ZOMBIFIED_PIGLINS_BREAK_TURTLE_EGGS = GameRuleRegistry.register("canZombifiedPiglinsBreakTurtleEggs", DAMAGE_INCORPORATED_CATEGORY, GameRuleFactory.createBooleanRule(true));
+		CAN_ZOMBIE_VILLAGERS_BREAK_TURTLE_EGGS = GameRuleRegistry.register("canZombieVillagersBreakTurtleEggs", DAMAGE_INCORPORATED_CATEGORY, GameRuleFactory.createBooleanRule(true));
+		CAN_HUSKS_BREAK_TURTLE_EGGS = GameRuleRegistry.register("canHusksBreakTurtleEggs", DAMAGE_INCORPORATED_CATEGORY, GameRuleFactory.createBooleanRule(true));
 	}
 }

--- a/src/main/java/io/github/ennuil/damageincorporated/DamageIncorporatedMod.java
+++ b/src/main/java/io/github/ennuil/damageincorporated/DamageIncorporatedMod.java
@@ -42,6 +42,7 @@ public class DamageIncorporatedMod implements ModInitializer {
 	public static GameRules.Key<BooleanRule> CAN_ZOMBIFIED_PIGLINS_BREAK_TURTLE_EGGS;
 	public static GameRules.Key<BooleanRule> CAN_HUSKS_BREAK_TURTLE_EGGS;
 	public static GameRules.Key<BooleanRule> CAN_ZOMBIE_VILLAGERS_BREAK_TURTLE_EGGS;
+	public static GameRules.Key<BooleanRule> CAN_MOBS_ON_FIRE_DESTROY_POWDER_SNOW_BLOCKS;
 	public static enum FARMLAND_TRAMPLING_ENUM {
 		ALL,
 		PLAYER,
@@ -73,9 +74,9 @@ public class DamageIncorporatedMod implements ModInitializer {
 		CAN_FOXES_EAT_IN_WORLD_BERRIES_RULE = GameRuleRegistry.register("canFoxesEatInWorldBerries", DAMAGE_INCORPORATED_CATEGORY, GameRuleFactory.createBooleanRule(true));
 		CAN_ZOMBIES_BREAK_TURTLE_EGGS = GameRuleRegistry.register("canZombiesBreakTurtleEggs", DAMAGE_INCORPORATED_CATEGORY, GameRuleFactory.createBooleanRule(true));
 		CAN_DROWNEDS_BREAK_TURTLE_EGGS = GameRuleRegistry.register("canDrownedBreakTurtleEggs", DAMAGE_INCORPORATED_CATEGORY, GameRuleFactory.createBooleanRule(true));
-		//CAN_SKELENTONS_BREAK_TURTLE_EGGS = GameRuleRegistry.register("canSkeletonsBreakTurtleEggs", DAMAGE_INCORPORATED_CATEGORY, GameRuleFactory.createBooleanRule(true));
 		CAN_ZOMBIFIED_PIGLINS_BREAK_TURTLE_EGGS = GameRuleRegistry.register("canZombifiedPiglinsBreakTurtleEggs", DAMAGE_INCORPORATED_CATEGORY, GameRuleFactory.createBooleanRule(true));
 		CAN_ZOMBIE_VILLAGERS_BREAK_TURTLE_EGGS = GameRuleRegistry.register("canZombieVillagersBreakTurtleEggs", DAMAGE_INCORPORATED_CATEGORY, GameRuleFactory.createBooleanRule(true));
 		CAN_HUSKS_BREAK_TURTLE_EGGS = GameRuleRegistry.register("canHusksBreakTurtleEggs", DAMAGE_INCORPORATED_CATEGORY, GameRuleFactory.createBooleanRule(true));
+		CAN_MOBS_ON_FIRE_DESTROY_POWDER_SNOW_BLOCKS = GameRuleRegistry.register("canMobsOnFireDestroyPowderSnowBlocks",DAMAGE_INCORPORATED_CATEGORY,GameRuleFactory.createBooleanRule(true));
 	}
 }

--- a/src/main/java/io/github/ennuil/damageincorporated/DamageIncorporatedMod.java
+++ b/src/main/java/io/github/ennuil/damageincorporated/DamageIncorporatedMod.java
@@ -43,6 +43,7 @@ public class DamageIncorporatedMod implements ModInitializer {
 	public static GameRules.Key<BooleanRule> CAN_HUSKS_BREAK_TURTLE_EGGS;
 	public static GameRules.Key<BooleanRule> CAN_ZOMBIE_VILLAGERS_BREAK_TURTLE_EGGS;
 	public static GameRules.Key<BooleanRule> CAN_MOBS_ON_FIRE_DESTROY_POWDER_SNOW_BLOCKS;
+	public static GameRules.Key<BooleanRule> CAN_RAVAGERS_BREAK_BLOCKS;
 	public static enum FARMLAND_TRAMPLING_ENUM {
 		ALL,
 		PLAYER,
@@ -78,5 +79,6 @@ public class DamageIncorporatedMod implements ModInitializer {
 		CAN_ZOMBIE_VILLAGERS_BREAK_TURTLE_EGGS = GameRuleRegistry.register("canZombieVillagersBreakTurtleEggs", DAMAGE_INCORPORATED_CATEGORY, GameRuleFactory.createBooleanRule(true));
 		CAN_HUSKS_BREAK_TURTLE_EGGS = GameRuleRegistry.register("canHusksBreakTurtleEggs", DAMAGE_INCORPORATED_CATEGORY, GameRuleFactory.createBooleanRule(true));
 		CAN_MOBS_ON_FIRE_DESTROY_POWDER_SNOW_BLOCKS = GameRuleRegistry.register("canMobsOnFireDestroyPowderSnowBlocks",DAMAGE_INCORPORATED_CATEGORY,GameRuleFactory.createBooleanRule(true));
+		CAN_RAVAGERS_BREAK_BLOCKS = GameRuleRegistry.register("canRavagersBreakBlocks",DAMAGE_INCORPORATED_CATEGORY,GameRuleFactory.createBooleanRule(true));
 	}
 }

--- a/src/main/java/io/github/ennuil/damageincorporated/mixin/PowderSnowBlockMixin.java
+++ b/src/main/java/io/github/ennuil/damageincorporated/mixin/PowderSnowBlockMixin.java
@@ -1,0 +1,26 @@
+package io.github.ennuil.damageincorporated.mixin;
+
+import io.github.ennuil.damageincorporated.DamageIncorporatedMod;
+import net.minecraft.block.Block;
+import net.minecraft.block.PowderSnowBlock;
+import net.minecraft.world.GameRules;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(PowderSnowBlock.class)
+public class PowderSnowBlockMixin extends Block {
+    public PowderSnowBlockMixin(Settings settings) {
+        super(settings);
+    }
+
+    @Redirect(
+            method = "onEntityCollision",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/GameRules;getBoolean(Lnet/minecraft/world/GameRules$Key;)Z", ordinal = 0)
+    )
+    public boolean redirectMobGriefing(GameRules gameRules, GameRules.Key<GameRules.BooleanRule> rule){
+        if(!gameRules.getBoolean(DamageIncorporatedMod.CAN_MOBS_ON_FIRE_DESTROY_POWDER_SNOW_BLOCKS))
+            return false;
+        return gameRules.getBoolean(GameRules.DO_MOB_GRIEFING);
+    }
+}

--- a/src/main/java/io/github/ennuil/damageincorporated/mixin/RavagerEntityMixin.java
+++ b/src/main/java/io/github/ennuil/damageincorporated/mixin/RavagerEntityMixin.java
@@ -1,0 +1,40 @@
+package io.github.ennuil.damageincorporated.mixin;
+
+import io.github.ennuil.damageincorporated.DamageIncorporatedMod;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.mob.RavagerEntity;
+import net.minecraft.entity.raid.RaiderEntity;
+import net.minecraft.sound.SoundEvent;
+import net.minecraft.world.GameRules;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(RavagerEntity.class)
+public class RavagerEntityMixin extends RaiderEntity {
+    protected RavagerEntityMixin(EntityType<? extends RaiderEntity> entityType, World world) {
+        super(entityType, world);
+    }
+
+    @Redirect(
+            method = "tickMovement",
+            at = @At(value = "INVOKE",target = "Lnet/minecraft/world/GameRules;getBoolean(Lnet/minecraft/world/GameRules$Key;)Z", ordinal = 0)
+    )
+    private boolean redirectMobGriefing(GameRules gameRules, GameRules.Key<GameRules.BooleanRule> rule){
+        if(!gameRules.getBoolean(DamageIncorporatedMod.CAN_RAVAGERS_BREAK_BLOCKS))
+            return false;
+        return gameRules.getBoolean(GameRules.DO_MOB_GRIEFING);
+    }
+
+    @Shadow
+    public void addBonusForWave(int wave, boolean unused) {
+
+    }
+
+    @Shadow
+    public SoundEvent getCelebratingSound() {
+        return null;
+    }
+}

--- a/src/main/java/io/github/ennuil/damageincorporated/mixin/StepAndDestroyBlockGoalMixin.java
+++ b/src/main/java/io/github/ennuil/damageincorporated/mixin/StepAndDestroyBlockGoalMixin.java
@@ -1,0 +1,60 @@
+package io.github.ennuil.damageincorporated.mixin;
+
+import io.github.ennuil.damageincorporated.DamageIncorporatedMod;
+import net.minecraft.block.Block;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.ai.goal.MoveToTargetPosGoal;
+import net.minecraft.entity.ai.goal.StepAndDestroyBlockGoal;
+import net.minecraft.entity.mob.*;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.GameRules;
+import net.minecraft.world.WorldView;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(StepAndDestroyBlockGoal.class)
+public class StepAndDestroyBlockGoalMixin extends MoveToTargetPosGoal {
+    public StepAndDestroyBlockGoalMixin(PathAwareEntity mob, double speed, int range, MobEntity stepAndDestroyMob, Block targetBlock) {
+        super(mob, speed, range);
+        this.stepAndDestroyMob = stepAndDestroyMob;
+    }
+
+    @Shadow @Final
+    @Mutable
+    private final MobEntity stepAndDestroyMob;
+
+    @Redirect(
+            method = "canStart",
+            at = @At(value = "INVOKE",target = "Lnet/minecraft/world/GameRules;getBoolean(Lnet/minecraft/world/GameRules$Key;)Z", ordinal = 0)
+    )
+    private boolean redirectMobGriefing(GameRules gameRules, GameRules.Key<GameRules.BooleanRule> rule){
+        if(this.stepAndDestroyMob.getType() == EntityType.ZOMBIE
+                && !gameRules.getBoolean(DamageIncorporatedMod.CAN_ZOMBIES_BREAK_TURTLE_EGGS)){
+            return false;
+        }else if(this.stepAndDestroyMob.getType() == EntityType.ZOMBIFIED_PIGLIN
+                && !gameRules.getBoolean(DamageIncorporatedMod.CAN_ZOMBIFIED_PIGLINS_BREAK_TURTLE_EGGS)){
+            return false;
+        }else if(this.stepAndDestroyMob.getType() == EntityType.ZOMBIE_VILLAGER
+                && !gameRules.getBoolean(DamageIncorporatedMod.CAN_ZOMBIE_VILLAGERS_BREAK_TURTLE_EGGS)){
+            return false;
+        }else if(this.stepAndDestroyMob.getType() == EntityType.DROWNED
+                && !gameRules.getBoolean(DamageIncorporatedMod.CAN_DROWNEDS_BREAK_TURTLE_EGGS)){
+            return false;
+        }else if(this.stepAndDestroyMob.getType() == EntityType.HUSK
+                && !gameRules.getBoolean(DamageIncorporatedMod.CAN_HUSKS_BREAK_TURTLE_EGGS)){
+            return false;
+        }else {
+            return gameRules.getBoolean(GameRules.DO_MOB_GRIEFING);
+        }
+    }
+
+    @Shadow
+    protected boolean isTargetPos(WorldView world, BlockPos pos) {
+        return false;
+    }
+}

--- a/src/main/resources/damageincorporated.mixins.json
+++ b/src/main/resources/damageincorporated.mixins.json
@@ -13,6 +13,7 @@
     "MobEntityMixin",
     "PickUpBlockGoalMixin",
     "PlaceBlockGoalMixin",
+    "PowderSnowBlockMixin",
     "SnowGolemEntityMixin",
     "StepAndDestroyBlockGoalMixin",
     "WanderAndInfestGoalMixin",

--- a/src/main/resources/damageincorporated.mixins.json
+++ b/src/main/resources/damageincorporated.mixins.json
@@ -14,6 +14,7 @@
     "PickUpBlockGoalMixin",
     "PlaceBlockGoalMixin",
     "SnowGolemEntityMixin",
+    "StepAndDestroyBlockGoalMixin",
     "WanderAndInfestGoalMixin",
     "WitherEntityMixin",
     "WitherSkullEntityMixin",

--- a/src/main/resources/damageincorporated.mixins.json
+++ b/src/main/resources/damageincorporated.mixins.json
@@ -14,6 +14,7 @@
     "PickUpBlockGoalMixin",
     "PlaceBlockGoalMixin",
     "PowderSnowBlockMixin",
+    "RavagerEntityMixin",
     "SnowGolemEntityMixin",
     "StepAndDestroyBlockGoalMixin",
     "WanderAndInfestGoalMixin",


### PR DESCRIPTION
Added GameRules for Zombies and Zombie Variants Stepping on and destroying turtle eggs, Powder Snow Block Getting destroyed when a mob on fire goes through with it, and ravagers breaking blocks